### PR TITLE
Model garden FLUX.1 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ gcloud run deploy genmedia-arena --source . \
     --region us-central1
 ```
 
+## Application Code Layout & Extending the App 
+
+The Arena application is an example of the Studio Scaffold. This includes the following components:
+
+Mesop Application modules
+
+* main.py - Mesop application main entry point
+* Components - Mesop UX components used in the Mesop application
+* Pages - Mesop UX Pages
+* State - Mesop State management
+* Config - Application and service configuration parameters
+
+Common Cloud and Generative AI Modules
+
+* Common - modules for interacting with Cloud services, sucn as Firestore, Storage
+* Models - Generative AI model modules
+
+
+### Extending the UX
+
+To extend the UX, for example, by adding pages - you'll add a Page, using UX components in Components, and then modify the components/side_nav.py to reference the Page for access in the navigation.
+
+### Extending the Model Capabilities
+
+To extend the model usage, for example adding in a Model Garden model such as FLUX.1 - add the implementation of FLUX.1 image generation to the Models module, and then modify the UX to invoke that model in the pages/arena.py Page.
+
 
 # Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ To extend the UX, for example, by adding pages - you'll add a Page, using UX com
 
 ### Extending the Model Capabilities
 
-To extend the model usage, for example adding in a Model Garden model such as FLUX.1 - add the implementation of FLUX.1 image generation to the Models module, and then modify the UX to invoke that model in the pages/arena.py Page.
+To extend the model usage, for example adding in a Model Garden model such as [FLUX.1](https://console.cloud.google.com/vertex-ai/publishers/black-forest-labs/model-garden/flux1-schnell) - add the implementation of FLUX.1 image generation to the Models module, and then modify the UX to invoke that model in the `pages/arena.py` Page. This may also require adding in any explicit configurations to the Config module, `config/default.py`.
+
+Follow [Model Garden](https://cloud.google.com/vertex-ai/generative-ai/docs/model-garden/explore-models) instructions on how to deploy [FLUX.1](https://console.cloud.google.com/vertex-ai/publishers/black-forest-labs/model-garden/flux1-schnell). 
 
 
 # Disclaimer

--- a/config/default.py
+++ b/config/default.py
@@ -49,7 +49,7 @@ class Default:
 
     # model garden image models
     MODEL_FLUX1 = "black-forest-labs/FLUX.1-schnell"
-    MODEL_FLUX1_ENDPOINT = "9021247714809085952" #"flux1-schnell-1736198391493@1"
+    MODEL_FLUX1_ENDPOINT = os.environ.get("FLUX1_MODEL_ID")
 
 
     # pylint: disable=invalid-name

--- a/config/default.py
+++ b/config/default.py
@@ -32,11 +32,12 @@ class Default:
 
     # pylint: disable=invalid-name
     PROJECT_ID: str = os.environ.get("PROJECT_ID")
+    PROJECT_NUMBER: str = os.environ.get("PROJECT_NUMBER")
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
     MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-2.0-flash-exp")
     INIT_VERTEX: bool = True
 
-    GENMEDIA_BUCKET = os.environ.get("GENMEDIA_BUCKET")
+    GENMEDIA_BUCKET = os.environ.get("GENMEDIA_BUCKET", f"{PROJECT_ID}-genmedia")
     IMAGE_COLLECTION_NAME = os.environ.get("IMAGE_COLLECTION_NAME", "arena_images")
     IMAGE_RATINGS_COLLECTION_NAME = os.environ.get("IMAGE_RATINGS_COLLECTION_NAME", "arena_elo")
     ELO_K_FACTOR = os.environ.get("ELO_K_FACTOR", 32)
@@ -45,5 +46,10 @@ class Default:
     MODEL_IMAGEN2 = "imagegeneration@006"
     MODEL_IMAGEN3_FAST = "imagen-3.0-fast-generate-001"
     MODEL_IMAGEN3 = "imagen-3.0-generate-001"
+    
+    # model garden image models
+    MODEL_FLUX1 = "black-forest-labs/FLUX.1-schnell"
+    MODEL_FLUX1_ENDPOINT = "9021247714809085952" #"flux1-schnell-1736198391493@1"
+
 
     # pylint: disable=invalid-name

--- a/config/default.py
+++ b/config/default.py
@@ -14,7 +14,7 @@
 """ Default Configuration for GenMedia Arena """
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from dotenv import load_dotenv
 
 
@@ -46,7 +46,7 @@ class Default:
     MODEL_IMAGEN2 = "imagegeneration@006"
     MODEL_IMAGEN3_FAST = "imagen-3.0-fast-generate-001"
     MODEL_IMAGEN3 = "imagen-3.0-generate-001"
-    
+
     # model garden image models
     MODEL_FLUX1 = "black-forest-labs/FLUX.1-schnell"
     MODEL_FLUX1_ENDPOINT = "9021247714809085952" #"flux1-schnell-1736198391493@1"

--- a/config/firebase_app.py
+++ b/config/firebase_app.py
@@ -24,6 +24,6 @@ def initialize_firebase():
         return firestore.client()
     except ValueError:
         print("Firebase already initialized.")
-        return firestore.client() 
+        return firestore.client()
 
 initialize_firebase()

--- a/models/model_garden_flux.py
+++ b/models/model_garden_flux.py
@@ -1,0 +1,115 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""" Flux.1 model (Vertex AI Model Garden) """
+
+import base64
+import io
+import logging
+import time
+from typing import Any
+import uuid
+
+from PIL import Image
+
+from google.cloud import aiplatform
+
+from config.default import Default
+from common.storage import store_to_gcs
+from common.metadata import add_image_metadata
+
+
+
+config = Default()
+logging.basicConfig(level=logging.DEBUG)
+
+
+def base64_to_image(image_str: str) -> Any:
+    """Convert base64 encoded string to an image.
+
+    Args:
+      image_str: A string of base64 encoded image.
+
+    Returns:
+      A PIL.Image instance.
+    """
+    image = Image.open(io.BytesIO(base64.b64decode(image_str)))
+    return image
+
+
+def flux_generate_images(model_name: str, prompt: str, aspect_ratio: str):
+    """
+    Creates images from Model Garden deployed Flux.1 model,
+    Returns a list of gcs uris
+    """
+
+    start_time = time.time()
+
+    arena_output = []
+    print(f"model: {model_name}")
+    print(f"prompt: {prompt}")
+    print(f"target output: {config.GENMEDIA_BUCKET}")
+
+    aiplatform.init(project=config.PROJECT_ID, location=config.LOCATION)
+
+    instances = [{"text": prompt}]
+    parameters = {
+        "height": 1024,
+        "width": 1024,
+        "num_inference_steps": 4,
+    }
+
+    endpoint = aiplatform.Endpoint(
+        f"projects/{config.PROJECT_NUMBER}/locations/{config.LOCATION}/endpoints/{config.MODEL_FLUX1_ENDPOINT}"
+    )
+
+    response = endpoint.predict(
+        instances=instances,
+        parameters=parameters,
+    )
+
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+
+    images = [
+        #base64_to_image(prediction.get("output")) for prediction in response.predictions
+        prediction.get("output") for prediction in response.predictions
+    ]
+
+    for idx, img in enumerate(images):
+        logging.info(
+            "Generated image %s with model %s in %s seconds",
+            idx,
+            model_name,
+            f"{elapsed_time:.2f}",
+        )
+
+        gcs_uri = store_to_gcs("flux1", f"{uuid.uuid4()}.png", "image/png", img, True)
+        gcs_uri = f"gs://{gcs_uri}" # append "gs://"
+
+        logging.info(
+            "generated image: %s len %s at %s", idx, len(img), gcs_uri
+        )
+        # output = img._as_base64_string()
+        # state.image_output.append(output)
+        arena_output.append(gcs_uri)
+        logging.info("image created: %s", gcs_uri)
+        try:
+            add_image_metadata(gcs_uri, prompt, model_name)
+        except Exception as e:
+            if "DeadlineExceeded" in str(e):  # Check for timeout error
+                logging.error("Firestore timeout: %s", e)
+            else:
+                logging.error("Error adding image metadata: %s", e)
+
+    return arena_output

--- a/models/model_garden_flux.py
+++ b/models/model_garden_flux.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-""" Flux.1 model (Vertex AI Model Garden) """
+""" FLUX.1 model (Vertex AI Model Garden) """
 
 import base64
 import io
@@ -27,7 +27,6 @@ from google.cloud import aiplatform
 from config.default import Default
 from common.storage import store_to_gcs
 from common.metadata import add_image_metadata
-
 
 
 config = Default()
@@ -56,9 +55,9 @@ def flux_generate_images(model_name: str, prompt: str, aspect_ratio: str):
     start_time = time.time()
 
     arena_output = []
-    print(f"model: {model_name}")
-    print(f"prompt: {prompt}")
-    print(f"target output: {config.GENMEDIA_BUCKET}")
+    logging.info("model: %s", model_name)
+    logging.info("prompt: %s", prompt)
+    logging.info("target output: %s", config.GENMEDIA_BUCKET)
 
     aiplatform.init(project=config.PROJECT_ID, location=config.LOCATION)
 
@@ -82,8 +81,9 @@ def flux_generate_images(model_name: str, prompt: str, aspect_ratio: str):
     elapsed_time = end_time - start_time
 
     images = [
-        #base64_to_image(prediction.get("output")) for prediction in response.predictions
-        prediction.get("output") for prediction in response.predictions
+        # base64_to_image(prediction.get("output")) for prediction in response.predictions
+        prediction.get("output")
+        for prediction in response.predictions
     ]
 
     for idx, img in enumerate(images):
@@ -95,11 +95,9 @@ def flux_generate_images(model_name: str, prompt: str, aspect_ratio: str):
         )
 
         gcs_uri = store_to_gcs("flux1", f"{uuid.uuid4()}.png", "image/png", img, True)
-        gcs_uri = f"gs://{gcs_uri}" # append "gs://"
+        gcs_uri = f"gs://{gcs_uri}"  # append "gs://"
 
-        logging.info(
-            "generated image: %s len %s at %s", idx, len(img), gcs_uri
-        )
+        logging.info("generated image: %s len %s at %s", idx, len(img), gcs_uri)
         # output = img._as_base64_string()
         # state.image_output.append(output)
         arena_output.append(gcs_uri)

--- a/pages/arena.py
+++ b/pages/arena.py
@@ -50,7 +50,7 @@ image_models = [
     Default.MODEL_IMAGEN2,
     Default.MODEL_IMAGEN3_FAST,
     Default.MODEL_IMAGEN3,
-    Default.MODEL_FLUX1,
+    # Default.MODEL_FLUX1,
     # "gemini2",
 ]
 
@@ -110,15 +110,18 @@ def arena_images(input: str):
             state.arena_output.append(generate_images(prompt))
 
         elif state.arena_model1.startswith(config.MODEL_FLUX1):
-            logging.info("model: %s", state.arena_model1)
-            futures.append(
-                executor.submit(
-                    flux_generate_images,
-                    state.arena_model1,
-                    prompt,
-                    state.image_aspect_ratio,
+            if config.MODEL_FLUX1_ENDPOINT:
+                logging.info("model: %s", state.arena_model1)
+                futures.append(
+                    executor.submit(
+                        flux_generate_images,
+                        state.arena_model1,
+                        prompt,
+                        state.image_aspect_ratio,
+                    )
                 )
-            )
+            else:
+                logging.info("no endpoint defined for %s", config.MODEL_FLUX1)
 
         # model 2
         if state.arena_model2.startswith("image"):
@@ -137,15 +140,18 @@ def arena_images(input: str):
             state.arena_output.append(generate_images(prompt))
 
         elif state.arena_model2.startswith(config.MODEL_FLUX1):
-            logging.info("model: %s", state.arena_model2)
-            futures.append(
-                executor.submit(
-                    flux_generate_images,
-                    state.arena_model2,
-                    prompt,
-                    state.image_aspect_ratio,
+            if config.MODEL_FLUX1_ENDPOINT:
+                logging.info("model: %s", state.arena_model2)
+                futures.append(
+                    executor.submit(
+                        flux_generate_images,
+                        state.arena_model2,
+                        prompt,
+                        state.image_aspect_ratio,
+                    )
                 )
-            )
+            else:
+                logging.info("no endpoint defined for %s", config.MODEL_FLUX1)
 
         for future in as_completed(futures):  # Wait for tasks to complete
             try:

--- a/pages/arena.py
+++ b/pages/arena.py
@@ -34,12 +34,11 @@ from state.state import AppState
 from components.header import header
 
 from models.set_up import ModelSetup
-
 from models.gemini_model import (
     generate_content,
     generate_images,
 )
-
+from models.model_garden_flux import flux_generate_images
 
 # Initialize configuration
 client, model_id = ModelSetup.init()
@@ -51,8 +50,8 @@ image_models = [
     Default.MODEL_IMAGEN2,
     Default.MODEL_IMAGEN3_FAST,
     Default.MODEL_IMAGEN3,
+    Default.MODEL_FLUX1,
     # "gemini2",
-    # "black-forest-labs/FLUX.1-schnell"
 ]
 
 
@@ -93,6 +92,7 @@ def arena_images(input: str):
     # print(f"model: {state.arena_model1}")
     # model1 = ImageGenerationModel.from_pretrained(state.arena_model1)
 
+        # model 1
         if state.arena_model1.startswith("image"):
             futures.append(
                 executor.submit(
@@ -109,6 +109,18 @@ def arena_images(input: str):
             logging.info("model: %s", state.arena_model1)
             state.arena_output.append(generate_images(prompt))
 
+        elif state.arena_model1.startswith(config.MODEL_FLUX1):
+            logging.info("model: %s", state.arena_model1)
+            futures.append(
+                executor.submit(
+                    flux_generate_images,
+                    state.arena_model1,
+                    prompt,
+                    state.image_aspect_ratio,
+                )
+            )
+
+        # model 2
         if state.arena_model2.startswith("image"):
             futures.append(
                 executor.submit(
@@ -120,9 +132,20 @@ def arena_images(input: str):
             )
             # state.arena_output.extend(imagen_generate_images(state.arena_model2, prompt, state.image_aspect_ratio))
 
-        elif state.arena_model1 == "gemini2":
+        elif state.arena_model2 == "gemini2":
             logging.info("model: %s", state.arena_model2)
             state.arena_output.append(generate_images(prompt))
+
+        elif state.arena_model2.startswith(config.MODEL_FLUX1):
+            logging.info("model: %s", state.arena_model2)
+            futures.append(
+                executor.submit(
+                    flux_generate_images,
+                    state.arena_model2,
+                    prompt,
+                    state.image_aspect_ratio,
+                )
+            )
 
         for future in as_completed(futures):  # Wait for tasks to complete
             try:
@@ -144,9 +167,9 @@ def imagen_generate_images(model_name: str, prompt: str, aspect_ratio: str):
     Returns:
         _type_: a list of strings (gcs uris of image output)
     """
-    
-    start_time = time.time() 
-    
+
+    start_time = time.time()
+
     arena_output = []
     print(f"model: {model_name}")
     print(f"prompt: {prompt}")
@@ -215,7 +238,7 @@ def on_click_reload_arena(e: me.ClickEvent):  # pylint: disable=unused-argument
 
     # get random images
     state.arena_model1, state.arena_model2 = random.sample(image_models, 2)
-    print(f"{state.arena_model1} vs. {state.arena_model2}")
+    print(f"BATTLE: {state.arena_model1} vs. {state.arena_model2}")
     arena_images(state.arena_prompt)
 
     state.is_loading = False


### PR DESCRIPTION
Fixes #13  with example of changes for incorporating a Model Garden model, FLUX.1 schnell.

Modifications include:

* pages/arena.py - addition of call to implementation, with guard on config parameter presence; model commented out in list of `image_models`
* config/default.py - addition of FLUX.1 config parameters
* models/model_garden_flux.py - implementation of generating images with FLUX.1
* README.md - describes app code outline, notes files changed for modifications/extensions
* minor refactors to appease linter