### PR TITLE
Add Stable Diffusion to the battle field 

### DIFF
--- a/common/metadata.py
+++ b/common/metadata.py
@@ -15,7 +15,6 @@
 import datetime
 import json
 import os
-from turtle import st
 from typing import Optional, Dict, Any, List
 import pandas as pd
 

--- a/common/metadata.py
+++ b/common/metadata.py
@@ -141,7 +141,7 @@ def load_metadata_from_json(
                     bar()  # Increment the progress bar
                     continue
 
-                print(f"Adding metadata for prompt: '{prompt}' with image URI: {selected_image_gcsuri})...")
+                print(f"Adding metadata for prompt: '{prompt}' with image URI: {selected_image_gcsuri}...")
                 add_image_metadata(collection_name=collection_name, gcsuri=selected_image_gcsuri, prompt=prompt, model=model_name)
                 bar()  # Increment the progress bar
 

--- a/common/storage.py
+++ b/common/storage.py
@@ -50,3 +50,14 @@ def download_gcs_blob(gs_uri: str) -> bytes:
     blob = gcs_client.bucket(bucket).blob(blob)
     blob_content = blob.download_as_bytes()
     return blob_content
+
+def check_gcs_blob_exists(gcs_blob_uri: str) -> bool:
+    """Check if a GCS blob exists."""
+    try:
+        gcs_client: storage.Client = storage.Client(project=cfg.PROJECT_ID)
+        bucket, blob = gcs_blob_uri[5:].split("/", maxsplit=1)
+        blob = gcs_client.bucket(bucket).blob(blob)
+        return blob.exists()
+    except Exception as e:
+        print(f"Error checking existence of {gcs_blob_uri}: {e}")
+        return False

--- a/config/default.py
+++ b/config/default.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 """ Default Configuration for GenMedia Arena """
 
+import json
 import os
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from dotenv import load_dotenv
 
-
 load_dotenv(override=True)
-
 
 @dataclass
 class GeminiModelConfig:
@@ -34,27 +33,31 @@ class Default:
     PROJECT_ID: str = os.environ.get("PROJECT_ID")
     LOCATION: str = os.environ.get("LOCATION", "us-central1")
     MODEL_ID: str = os.environ.get("MODEL_ID", "gemini-2.0-flash")
-    INIT_VERTEX: bool = True
+    INIT_VERTEX: bool = os.environ.get("INIT_VERTEX", "True").lower() in ("true", "1")
 
-    GENMEDIA_BUCKET = os.environ.get("GENMEDIA_BUCKET")
-    IMAGE_FIREBASE_DB = os.environ.get("IMAGE_FIREBASE_DB", "")
-    IMAGE_COLLECTION_NAME = os.environ.get("IMAGE_COLLECTION_NAME", "arena_images")
-    STUDY_COLLECTION_NAME = os.environ.get("STUDY_COLLECTION_NAME", "arena_study")
-    IMAGE_RATINGS_COLLECTION_NAME = os.environ.get("IMAGE_RATINGS_COLLECTION_NAME", "arena_elo")
-    DEFAULT_PROMPTS = "prompts/imagen_prompts.json"
-    ELO_K_FACTOR = int(os.environ.get("ELO_K_FACTOR", 32))
+    GENMEDIA_BUCKET: str = os.environ.get("GENMEDIA_BUCKET")
+    IMAGE_FIREBASE_DB: str = os.environ.get("IMAGE_FIREBASE_DB")
+    IMAGE_COLLECTION_NAME = os.environ.get("IMAGE_COLLECTION_NAME")
+    STUDY_COLLECTION_NAME: str = os.environ.get("STUDY_COLLECTION_NAME", "arena_study")
+    IMAGE_RATINGS_COLLECTION_NAME: str = os.environ.get("IMAGE_RATINGS_COLLECTION_NAME", "arena_elo")
+    STABLE_DIFFUSION_DB_PROMPTS: str = os.environ.get("STABLE_DIFFUSION_DB_PROMPTS", "prompts/stable_diffusion_prompts.json")
+    DEFAULT_PROMPTS: str = os.environ.get("DEFAULT_PROMPTS", "prompts/imagen_prompts.json")
+    DEFAULT_STUDY_NAME: str = os.environ.get("DEFAULT_STUDY_NAME", "live")
+    ELO_K_FACTOR: int = int(os.environ.get("ELO_K_FACTOR", 32))
 
     # image models
-    MODEL_IMAGEN2 = "imagegeneration@006"
-    MODEL_IMAGEN3_FAST = "imagen-3.0-fast-generate-001"
-    MODEL_IMAGEN3 = "imagen-3.0-generate-001"
-    MODEL_IMAGEN32 = "imagen-3.0-generate-002"
+    MODEL_IMAGEN2: str = "imagegeneration@006"
+    MODEL_IMAGEN3_FAST: str = "imagen-3.0-fast-generate-001"
+    MODEL_IMAGEN3: str = "imagen-3.0-generate-001"
+    MODEL_IMAGEN32: str = "imagen-3.0-generate-002"
     
-    MODEL_GEMINI2 = "gemini-2.0-flash"
+    MODEL_GEMINI2: str = "gemini-2.0-flash"
 
     # model garden image models
-    MODEL_FLUX1 = "black-forest-labs/FLUX.1-schnell"
-    MODEL_FLUX1_ENDPOINT_ID = os.environ.get("MODEL_FLUX1_ENDPOINT_ID")
+    MODEL_FLUX1: str = "black-forest-labs/FLUX.1-schnell"
+    MODEL_FLUX1_ENDPOINT_ID: str = os.environ.get("MODEL_FLUX1_ENDPOINT_ID")
+    MODEL_STABLE_DIFFUSION: str = "stabilityai/stable-diffusion-2.1"
+    MODEL_STABLE_DIFFUSION_ENDPOINT_ID: str = os.environ.get("MODEL_STABLE_DIFFUSION_ENDPOINT_ID")
 
     def __post_init__(self):
         """Validates the configuration variables after initialization."""
@@ -67,13 +70,25 @@ class Default:
 
         if not self.MODEL_FLUX1_ENDPOINT_ID:
             print("MODEL_FLUX1_ENDPOINT_ID environment variable is not set. List of models will exclude flux1") # Optional: List of models will exclude flux1
+        
+        if not self.MODEL_STABLE_DIFFUSION_ENDPOINT_ID:
+            print("MODEL_STABLE_DIFFUSION_ENDPOINT_ID environment variable is not set. List of models will exclude stable diffusion")
 
         if self.ELO_K_FACTOR <= 0:
             raise ValueError("ELO_K_FACTOR must be a positive integer.")
+
+        if not self.IMAGE_FIREBASE_DB:
+            raise ValueError("IMAGE_FIREBASE_DB environment variable is not set. Default will be used") 
+
+        if not self.IMAGE_COLLECTION_NAME:
+            raise ValueError("IMAGE_COLLECTION_NAME environment variable is not set.")
 
         valid_locations = ["us-central1", "us-east4", "europe-west4", "asia-east1"]  # example locations
         if self.LOCATION not in valid_locations:
             print(f"Warning: LOCATION {self.LOCATION} may not be valid.")
         print("Configuration validated successfully.")
+    
+    def __repr__(self):
+        return f"Default({json.dumps(asdict(self), indent=4)})"
 
     # pylint: disable=invalid-name

--- a/config/default.py
+++ b/config/default.py
@@ -54,9 +54,9 @@ class Default:
     MODEL_GEMINI2: str = "gemini-2.0-flash"
 
     # model garden image models
-    MODEL_FLUX1: str = "black-forest-labs/FLUX.1-schnell"
+    MODEL_FLUX1: str = "black-forest-labs/flux1-schnell"
     MODEL_FLUX1_ENDPOINT_ID: str = os.environ.get("MODEL_FLUX1_ENDPOINT_ID")
-    MODEL_STABLE_DIFFUSION: str = "stabilityai/stable-diffusion-2.1"
+    MODEL_STABLE_DIFFUSION: str = "stability-ai/stable-diffusion-2-1"
     MODEL_STABLE_DIFFUSION_ENDPOINT_ID: str = os.environ.get("MODEL_STABLE_DIFFUSION_ENDPOINT_ID")
 
     def __post_init__(self):

--- a/config/firebase_config.py
+++ b/config/firebase_config.py
@@ -31,7 +31,7 @@ class FirebaseClient:
         try:
             cred = credentials.ApplicationDefault()
             firebase_admin.initialize_app(cred)
-            print(f"[FirebaseClient] - initiating firebase client with `{database_id}`")
+            print(f"[FirebaseClient] - initiating firebase client with `{database_id}` on `{cred.project_id}`")
         except ValueError:
             print("[FirebaseClient] - Firebase already initialized.")
         self._client = firestore.client(database_id=database_id)

--- a/models/gemini_model.py
+++ b/models/gemini_model.py
@@ -43,7 +43,7 @@ MODEL_ID = model_id
     retry=retry_if_exception_type(Exception),  # Retry on all exceptions
     reraise=True,  # re-raise the last exception if all retries fail
 )
-def generate_images(prompt: str) -> str:
+def generate_images(prompt: str) -> list[str]:
     """generate image content"""
 
     try:
@@ -55,7 +55,7 @@ def generate_images(prompt: str) -> str:
             ),
         )
         print(f"success! {response.candidates[0].content}")
-        return response.text
+        return [res.text for res in response.candidates]
 
     except Exception as e:
         print(f"error: {e}")

--- a/models/generate.py
+++ b/models/generate.py
@@ -52,70 +52,181 @@ def base64_to_image(image_str: str) -> Any:
     image = Image.open(io.BytesIO(base64.b64decode(image_str)))
     return image
 
+def generate_images_from_model_garden(
+    prompt: str,
+    endpoint_id: str,
+    model_name: str,
+    output_gcs_folder: str,
+    parameters: dict[str, Any],
+    project_id: str = config.PROJECT_ID,
+    location: str = config.LOCATION,
+) -> list[str]:
+    """
+    Generates images using a specified endpoints of Model Garden deployed models.
 
-def images_from_flux(model_name: str, prompt: str, aspect_ratio: str):
+    Args:
+        prompt: The text prompt for image generation.
+        endpoint_id: The Vertex AI Endpoint ID to use.
+        model_name: A descriptive name for the model (for logging/metadata).
+        output_gcs_folder: The subfolder within config.GENMEDIA_BUCKET to store results.
+        parameters: A dictionary of parameters required by the specific model endpoint
+                    (e.g., height, width, num_inference_steps).
+        project_id: Google Cloud Project ID. Defaults to config.PROJECT_ID.
+        location: Google Cloud Location. Defaults to config.LOCATION.
+
+    Returns:
+        A list of GCS URIs for the generated images (e.g., ["gs://bucket/folder/uuid.png"]).
+
+    Raises:
+        ValueError: If required arguments are missing or invalid.
+        # Re-raises exceptions from aiplatform.Endpoint.predict
     """
-    Creates images from Model Garden deployed Flux.1 model,
-    Returns a list of gcs uris
-    """
-    _ = aspect_ratio  # aspect ratio is not used in this function
+    if not all([prompt, endpoint_id, model_name, output_gcs_folder, parameters]):
+        raise ValueError("Missing one or more required arguments: prompt, endpoint_id, model_name, output_gcs_folder, parameters")
+    if not isinstance(parameters, dict):
+        raise ValueError("parameters must be a dictionary")
+
+    logging.info(f"Generating image with endpoint model: {model_name}")
+    logging.info(f"Prompt: '{prompt}'")
+    logging.info(f"Endpoint ID: {endpoint_id}")
+    logging.info(f"Parameters: {parameters}")
+    logging.info(f"Target GCS Folder: gs://{config.GENMEDIA_BUCKET}/{output_gcs_folder}/")
+
+    aiplatform.init(project=project_id, location=location)
+
+    instances = [{"text": prompt}] 
+
+    endpoint_path = f"projects/{project_id}/locations/{location}/endpoints/{endpoint_id}"
+    endpoint = aiplatform.Endpoint(endpoint_path)
+
+    arena_output: list[str] = []
     start_time = time.time()
 
-    arena_output = []
-    logging.info("model: %s", model_name)
-    logging.info("prompt: %s", prompt)
-    logging.info("target output: %s", config.GENMEDIA_BUCKET)
+    try:
+        logging.info(f"Calling endpoint: {endpoint_path}")
+        response = endpoint.predict(
+            instances=instances,
+            parameters=parameters,
+        )
+        # logging.info(f"Received response from endpoint: {response}")
+        if not response or not hasattr(response, 'predictions') or not response.predictions:
+             logging.error("Received empty or invalid response from endpoint.")
+             return []
 
-    aiplatform.init(project=config.PROJECT_ID, location=config.LOCATION)
+        image_outputs = []
+        for prediction in response.predictions:
+             # Check common keys for base64 image data
+             img_data = prediction.get("output") or prediction.get("bytesBase64Encoded")
+             if img_data:
+                 image_outputs.append(img_data)
+             else:
+                 logging.warning(f"Prediction missing expected image data key ('output' or 'bytesBase64Encoded'): {prediction}")
 
-    instances = [{"text": prompt}]
-    parameters = {
-        "height": 1024,
-        "width": 1024,
-        "num_inference_steps": 4,
-    }
-
-    endpoint = aiplatform.Endpoint(
-        f"projects/{config.PROJECT_ID}/locations/{config.LOCATION}/endpoints/{config.MODEL_FLUX1_ENDPOINT_ID}"
-    )
-
-    print("calling endpoint")
-    response = endpoint.predict(
-        instances=instances,
-        parameters=parameters,
-    )
+        if not image_outputs:
+             logging.error("No valid image data found in any endpoint predictions.")
+             return [] # Or raise an error
+    except Exception as e:
+        logging.error(f"Error calling Vertex AI endpoint {endpoint_path}: {e}", exc_info=True)
+        raise
 
     end_time = time.time()
     elapsed_time = end_time - start_time
+    logging.info(f"Endpoint call finished in {elapsed_time:.2f} seconds. Processing {len(image_outputs)} images.")
 
-    images = [
-        # base64_to_image(prediction.get("output")) for prediction in response.predictions
-        prediction.get("output")
-        for prediction in response.predictions
-    ]
-
-    for idx, img in enumerate(images):
-        logging.info(
-            "Generated image %s with model %s in %s seconds",
-            idx,
-            model_name,
-            f"{elapsed_time:.2f}",
-        )
-
-        gcs_uri = store_to_gcs("flux1", f"{uuid.uuid4()}.png", "image/png", img, True)
-        gcs_uri = f"gs://{gcs_uri}"  # append "gs://"
-
-        logging.info("generated image: %s len %s at %s", idx, len(img), gcs_uri)
-        arena_output.append(gcs_uri)
-        logging.info("image created: %s", gcs_uri)
+    for idx, img_base64 in enumerate(image_outputs):
         try:
-            add_image_metadata(gcs_uri, prompt, model_name)
-        except Exception as e:
-            if "DeadlineExceeded" in str(e):  # Check for timeout error
-                logging.error("Firestore timeout: %s", e)
-            else:
-                logging.error("Error adding image metadata: %s", e)
+            image_filename = f"{uuid.uuid4()}.png"
+            gcs_path_suffix = store_to_gcs(
+                folder=output_gcs_folder,
+                file_name=image_filename,
+                mime_type="image/png",
+                contents=img_base64,
+                decode=True
+            )
+            # Construct full GCS URI
+            gcs_uri = f"gs://{gcs_path_suffix}"
+
+            logging.info(
+                f"Generated image {idx+1}/{len(image_outputs)} with model {model_name}. "
+                f"Stored at: {gcs_uri}"
+            )
+            arena_output.append(gcs_uri)
+
+            try:
+                add_image_metadata(gcs_uri, prompt, model_name)
+                logging.debug(f"Successfully added metadata for {gcs_uri}")
+            except Exception as ex:
+                if "DeadlineExceeded" in str(ex):
+                    logging.error(f"Firestore timeout adding metadata for {gcs_uri}: {ex}")
+                else:
+                    logging.error(f"Error adding image metadata for {gcs_uri}: {ex}", exc_info=True)
+
+        except Exception as ex:
+            logging.error(f"Error processing or uploading image {idx+1} from {model_name}: {ex}", exc_info=True)
+            # Continue with the next image
+
+    logging.info(f"Finished endpoint processing for model {model_name}. Returning {len(arena_output)} GCS URIs.")
     return arena_output
+
+def images_from_flux(model_name: str, prompt: str, aspect_ratio: str) -> list[str]:
+    """
+    Generates images using the configured Flux.1 model endpoint.
+
+    Args:
+        prompt: The text prompt.
+        params_override: Optional dictionary to override default parameters.
+
+    Returns:
+        A list of GCS URIs for the generated images.
+    """
+    _ = aspect_ratio  # aspect ratio is not used in this function
+    if not config.MODEL_FLUX1_ENDPOINT_ID:
+         raise ValueError("config.MODEL_FLUX1_ENDPOINT_ID is not set.")
+
+    default_params = {
+        "height": 1024,
+        "width": 1024,
+        "num_inference_steps": 4, # Default for Flux
+    }
+
+    return generate_images_from_model_garden(
+        prompt=prompt,
+        endpoint_id=config.MODEL_FLUX1_ENDPOINT_ID,
+        model_name=model_name,
+        output_gcs_folder="flux1",
+        parameters=default_params,
+    )
+
+def images_from_stable_diffusion(model_name: str, prompt: str, aspect_ratio: str) -> list[str]:
+    """
+    Generates images using the configured Stable Diffusion model endpoint.
+    *Adjust default_params based on your specific Stable Diffusion deployment.*
+
+    Args:
+        prompt: The text prompt.
+        params_override: Optional dictionary to override default parameters.
+
+    Returns:
+        A list of GCS URIs for the generated images.
+    """
+    _ = aspect_ratio  # aspect ratio is not used in this function
+    if not config.MODEL_STABLE_DIFFUSION_ENDPOINT_ID:
+         raise ValueError("config.MODEL_STABLE_DIFFUSION_ENDPOINT_ID is not set.")
+
+    default_params = {
+        "height": 1024,
+        "width": 1024,
+        "num_inference_steps": 25,  # Typically higher for SD
+        "guidance_scale": 7.5,     # Common SD parameter
+    }
+
+    return generate_images_from_model_garden(
+        prompt=prompt,
+        endpoint_id=config.MODEL_STABLE_DIFFUSION_ENDPOINT_ID,
+        model_name=model_name,
+        output_gcs_folder="stablediffusion", 
+        parameters=default_params,
+    )
 
 def images_from_imagen(model_name: str, prompt: str, aspect_ratio: str):
     """creates images from Imagen and returns a list of gcs uris

--- a/models/set_up.py
+++ b/models/set_up.py
@@ -24,6 +24,8 @@ def load_default_models() -> list[str]:
     IMAGE_GEN_MODELS = [config.MODEL_IMAGEN2, config.MODEL_IMAGEN3_FAST, config.MODEL_IMAGEN3, config.MODEL_IMAGEN32,]
     if config.MODEL_FLUX1_ENDPOINT_ID:
         IMAGE_GEN_MODELS.append(config.MODEL_FLUX1)
+    if config.MODEL_STABLE_DIFFUSION_ENDPOINT_ID:
+        IMAGE_GEN_MODELS.append(config.MODEL_STABLE_DIFFUSION)
     return IMAGE_GEN_MODELS
 
 

--- a/pages/arena.py
+++ b/pages/arena.py
@@ -21,10 +21,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import mesop as me
 
-from common.metadata import (
-    add_image_metadata,
-    update_elo_ratings,
-)
+from common.metadata import update_elo_ratings
 from config.default import Default
 from prompts.utils import PromptManager
 from state.state import AppState
@@ -49,12 +46,6 @@ logging.basicConfig(level=logging.DEBUG)
 
 IMAGEN_MODELS = [config.MODEL_IMAGEN2, config.MODEL_IMAGEN3_FAST, config.MODEL_IMAGEN3, config.MODEL_IMAGEN32,]
 GEMINI_MODELS = [config.MODEL_GEMINI2]
-
-# List of all image generation models
-# Check if flux1 endpoint is defined
-# IMAGE_GEN_MODELS = IMAGEN_MODELS
-# if config.MODEL_FLUX1_ENDPOINT_ID:
-#     IMAGE_GEN_MODELS.append(config.MODEL_FLUX1)
 
 
 @me.stateclass
@@ -190,7 +181,6 @@ def on_click_reload_arena(e: me.ClickEvent):  # pylint: disable=unused-argument
     state = me.state(PageState)
     if state.study == "live":
         state.study_models = load_default_models()
-    # IMAGE_GEN_MODELS = state.study_models
 
     state.arena_prompt = prompt_manager.random_prompt()
 
@@ -257,9 +247,6 @@ def arena_page_content(app_state: me.state):
     if page_state.study == "live":
         app_state.study_models = load_default_models()
     page_state.study_models = app_state.study_models
-    # IMAGE_GEN_MODELS = app_state.study_models
-    # print(IMAGE_GEN_MODELS)
-
 
     # TODO this is an initialization function that should be extracted
     if not app_state.welcome_message:

--- a/scripts/load_metadata_to_firestore.py
+++ b/scripts/load_metadata_to_firestore.py
@@ -92,15 +92,15 @@ def main(
             operations.
 
     Example Usage (from the command line):
-        ```bash
+        ```
         python load_metadata_to_firestore.py --json_file_path path/to/metadata.json --firestore_collection_name my_images
         ```
 
-        ```bash
+        ```
         python load_metadata_to_firestore.py --top_level_key generated_art --gcs_sub_folder final_renders
         ```
 
-        ```bash
+        ```
         python load_metadata_to_firestore.py --prompt_image_mapping "{'text': 'prompt', 'files': 'images'}"
         ```
     """

--- a/scripts/load_metadata_to_firestore.py
+++ b/scripts/load_metadata_to_firestore.py
@@ -1,0 +1,128 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Script to load SD metadata into Firestore."""
+import json
+from typing import Optional
+import fire
+from config.default import Default
+import logging
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv(override=True)
+
+cfg = Default()
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+
+def main(
+        collection_name: str = None,
+        json_file_path: str = None,
+        top_level_key: Optional[str] = "stable_diffusion",
+        gcs_sub_folder: Optional[str] = "stablediffusion",
+        model_name: Optional[str] = cfg.MODEL_STABLE_DIFFUSION,
+        prompt_image_mapping: Optional[dict[int, str]] = {0: "prompt", 1: "images"}
+):
+    """
+    Loads metadata from a JSON file and stores it in a Firestore collection.
+
+    This function reads a JSON file containing image metadata, typically prompts
+    and associated image filenames, and iterates through its entries to upload
+    the prompt and construct the Google Cloud Storage (GCS) URI for one of the
+    associated images. It then uses the `load_metadata_from_json` function
+    (assumed to be imported from `common.metadata`) to process this information
+    and store it as a document in the specified Firestore collection.
+
+    The function is designed to be run from the command line using the `fire`
+    library, allowing users to override default configuration values through
+    command-line arguments.
+
+    Args:
+        firestore_collection_name (str, optional): The name of the Firestore
+            collection where the metadata will be stored. Defaults to the value
+            of `Default.IMAGE_COLLECTION_NAME` from the `config.default` module.
+        json_file_path (str, optional): The path to the JSON file containing the
+            metadata. Defaults to the value of
+            `Default.STABLE_DIFFUSION_DB_PROMPTS` from the `config.default`
+            module. This file is expected to have a top-level key (specified by
+            `top_level_key`) whose value is a list of entries. Each entry is
+            expected to map a prompt to a list of associated image filenames
+            according to the `prompt_image_mapping`.
+        top_level_key (str, optional): The top-level key in the JSON file that
+            contains the list of metadata entries to process. Defaults to
+            "stable_diffusion".
+        gcs_sub_folder (str, optional): The sub-folder within the Google Cloud
+            Storage bucket where the image files are located. This is used to
+            construct the full GCS URI for an image. Defaults to "stablediffusion".
+        model_name (str, optional): The name of the machine learning model
+            associated with the generated images. This will be stored as part
+            of the metadata in Firestore. Defaults to the value of
+            `Default.MODEL_STABLE_DIFFUSION` from the `config.default` module.
+        prompt_image_mapping (dict[int, str], optional): A dictionary that
+            specifies how to extract the prompt and list of image filenames from
+            each entry in the list found under the `top_level_key` in the JSON
+            file. The keys of this dictionary are expected to be integer indices
+            (representing the position in a list or tuple), and the values are
+            strings representing the semantic meaning of the element at that
+            index (e.g., "prompt" and "images"). Defaults to `{0: "prompt", 1: "images"}`,
+            indicating that each entry is a list or tuple where the first element
+            is the prompt and the second element is a list of image filenames.
+
+    Raises:
+        FileNotFoundError: If the specified `json_file_path` does not exist.
+        json.JSONDecodeError: If the content of the `json_file_path` cannot be
+            parsed as valid JSON.
+        ValueError: If the `top_level_key` is not found in the loaded JSON,
+            or if the structure of the data under that key does not conform
+            to the expectations defined by `prompt_image_mapping`.
+        Other exceptions: May be raised by the underlying
+            `load_metadata_from_json` function or GCS/Firestore client
+            operations.
+
+    Example Usage (from the command line):
+        ```bash
+        python load_metadata_to_firestore.py --json_file_path path/to/metadata.json --firestore_collection_name my_images
+        ```
+
+        ```bash
+        python load_metadata_to_firestore.py --top_level_key generated_art --gcs_sub_folder final_renders
+        ```
+
+        ```bash
+        python load_metadata_to_firestore.py --prompt_image_mapping "{'text': 'prompt', 'files': 'images'}"
+        ```
+    """
+    try:
+        from common.metadata import load_metadata_from_json # lazy import 
+        load_metadata_from_json(
+            collection_name=collection_name,
+            json_file_path=json_file_path,
+            top_level_key=top_level_key,
+            gcs_sub_folder=gcs_sub_folder,
+            model_name=model_name,
+            key_mapping=prompt_image_mapping
+        )
+        logging.info("Metadata loading process completed successfully.")
+    except FileNotFoundError as e:
+        logging.error(f"Error: Metadata file not found at '{json_file_path}'. {e}")
+    except json.JSONDecodeError as e:
+        logging.error(f"Error: Failed to decode JSON from '{json_file_path}'. {e}")
+    except ValueError as e:
+        logging.error(f"Error during metadata loading: {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred: {e}")
+
+if __name__ == "__main__":
+    fire.Fire(main)


### PR DESCRIPTION
## Pull Request Overview

This PR introduces support for Stable Diffusion by adding functionality to load Stable Diffusion metadata into Firestore and integrating Stable Diffusion endpoints into the image generation workflow. Key changes include:
- Addition of the new script load_metadata_to_firestore.py for processing Stable Diffusion metadata.
- Updates to pages/arena.py and models/generate.py to incorporate Stable Diffusion endpoints.
- Updates to configuration and metadata handling to support Stable Diffusion integration.
